### PR TITLE
add a flags parameter to ws-connect, to allow for optional behavior

### DIFF
--- a/examples/simple-client.scm
+++ b/examples/simple-client.scm
@@ -1,9 +1,10 @@
 (import ws-client (chicken io) (chicken format))
 
 ;; connects to localhost:9001 and sends each line read from stdin
-;; until an empty line is encountered.
+;; until an empty line is encountered. strip the host name from
+;; the request line.
 
-(define conn (ws-connect "ws://localhost:9001"))
+(define conn (ws-connect "ws://localhost:9001" '() '(strip-host)))
 
 (send-text-message conn (read-line))
 

--- a/ws-client.wiki
+++ b/ws-client.wiki
@@ -33,7 +33,7 @@ Uses [[tcp6]] if it is imported together with this extension.
 
 <record>ws-connection</record>
 
-<procedure>(ws-connect STRING #!optional (list WS-EXTENSION ...)) -> WS-CONNECTION</procedure>
+<procedure>(ws-connect STRING #!optional (list WS-EXTENSION ...) (list SYMBOL ...)) -> WS-CONNECTION</procedure>
 
 The state of a WebSocket connection is stored in a record of type
 {{ws-connection}}.
@@ -49,6 +49,11 @@ The procedure {{ws-connect}} optionally accepts a list of extensions
 the client hopes to use. The only extension currently supported by
 this library is {{permessage-deflate}}; see the
 [[#the-permessage-deflateextension|relevant section]].
+
+The second optional argument is a list of flags (symbols). The only one
+currently supported is {{'strip-host}}, which strips the hostname, port,
+and scheme from the method line of the request. Some websocket implementations
+require this.
 
 ====== Sending and receiving messages
 


### PR DESCRIPTION
I'm writing a client for Slack's Api (https://api.slack.com/) and their websocket implementation does not allow the hostname and uri scheme to show up in the first line of the request. I've added an optional flags parameter to the `ws-connect` procedure to allow for this.

I'd like to update the wiki with documentation as well if this gets merged.

Thank you.